### PR TITLE
Add Next Gemfile Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,17 @@ For more information about using Ruby and buildpacks on Heroku, see these Dev Ce
 
 To use this buildpack, fork it on Github.  Push up changes to your fork, then create a test app with `--buildpack <your-github-url>` and push to it.
 
+
+## Next Rails
+
+This buildpack supports Next Rails version, to configure it follow the steps below:
+
+1. Make sure your app can boot with the next Rails version locally.
+2. Go to the Settings tab of your Heroku app, and add the `BUNDLE_GEMFILE` config var with `Gemfile.next` as a value.
+3. Go to the Buildpacks section and remove the `heroku/ruby` buildpack from your app and add `https://github.com/fastruby/heroku-buildpack-ruby#add_gemfile_next_support`
+4. Deploy your app to Heroku.
+5. The Next Rails version should be installed and your app should boot.
+
 ### Testing
 
 The tests on this buildpack are written in Rspec to allow the use of

--- a/lib/language_pack/helpers/bundler_wrapper.rb
+++ b/lib/language_pack/helpers/bundler_wrapper.rb
@@ -101,7 +101,7 @@ class LanguagePack::Helpers::BundlerWrapper
   def initialize(options = {})
     @bundler_tmp          = Pathname.new(Dir.mktmpdir)
     @fetcher              = options[:fetcher]      || LanguagePack::Fetcher.new(LanguagePack::Base::VENDOR_URL) # coupling
-    @gemfile_path         = options[:gemfile_path] || Pathname.new("./Gemfile")
+    @gemfile_path         = options[:gemfile_path] || Pathname.new(env("BUNDLE_GEMFILE") || "./Gemfile")
     @gemfile_lock_path    = Pathname.new("#{@gemfile_path}.lock")
 
     @version = self.class.detect_bundler_version(contents: @gemfile_lock_path.read(mode: "rt"))
@@ -223,7 +223,7 @@ class LanguagePack::Helpers::BundlerWrapper
   end
 
   def bundler_version_escape_valve!
-    topic("Removing BUNDLED WITH version in the Gemfile.lock")
+    topic("Removing BUNDLED WITH version in the #{@gemfile_lock_path}")
     contents = File.read(@gemfile_lock_path, mode: "rt")
     File.open(@gemfile_lock_path, "w") do |f|
       f.write contents.sub(/^BUNDLED WITH$(\r?\n)   (?<major>\d+)\.\d+\.\d+/m, '')

--- a/lib/language_pack/ruby.rb
+++ b/lib/language_pack/ruby.rb
@@ -141,7 +141,7 @@ WARNING
       build_bundler
       # TODO post_bundler might need to be done in a new layer
       bundler.clean
-      gem_layer.metadata[:gems] = Digest::SHA2.hexdigest(File.read("Gemfile.lock"))
+      gem_layer.metadata[:gems] = Digest::SHA2.hexdigest(File.read(gemfile_lock_path))
       gem_layer.metadata[:stack] = @stack
       gem_layer.metadata[:ruby_version] = run_stdout(%q(ruby -v)).strip
       gem_layer.metadata[:rubygems_version] = run_stdout(%q(gem -v)).strip
@@ -759,7 +759,7 @@ BUNDLE
       if bundler.windows_gemfile_lock?
         log("bundle", "has_windows_gemfile_lock")
 
-        File.unlink("Gemfile.lock")
+        File.unlink(gemfile_lock_path)
         ENV.delete("BUNDLE_DEPLOYMENT")
 
         warn(<<~WARNING, inline: true)
@@ -796,7 +796,7 @@ BUNDLE
 
         # we need to set BUNDLE_CONFIG and BUNDLE_GEMFILE for
         # codon since it uses bundler.
-        env_vars["BUNDLE_GEMFILE"] = "#{pwd}/Gemfile"
+        env_vars["BUNDLE_GEMFILE"] = "#{pwd}/#{gemfile_path}"
         env_vars["BUNDLE_CONFIG"] = "#{pwd}/.bundle/config"
         env_vars["CPATH"] = noshellescape("#{yaml_include}:$CPATH")
         env_vars["CPPATH"] = noshellescape("#{yaml_include}:$CPPATH")
@@ -1324,5 +1324,17 @@ MESSAGE
     @bundler_cache.clear(stack)
     # need to reinstall language pack gems
     install_bundler_in_app(slug_vendor_base)
+  end
+
+  def current_gemfile
+    env("BUNDLE_GEMFILE") || "Gemfile"
+  end
+
+  def gemfile_path
+    Pathname.new(current_gemfile)
+  end
+
+  def gemfile_lock_path
+    Pathname.new("#{current_gemfile}.lock")
   end
 end


### PR DESCRIPTION
Closes #1

We can run the next Rails version in Heroku

```bash
➜  fastruby.io git:(debug/heroku-buildpack-ruby) heroku run bash --app fastruby-staging
Running bash on ⬢ fastruby-staging... up, run.7123 (Basic)
~ $ rails --version
Rails 7.1.0
~ $ echo $BUNDLE_GEMFILE
Gemfile.next
```

IMPORTANT NOTES:

* How are we going to manage this change in the long term? When the people at Heroku release new changes we are going to miss them out, is it better to keep our changes in a branch and rebase their changes as time passes? For sure, it would be better if we propose these changes to the official build pack and get merged :crossed_fingers: 

* Switching between the current and next Rails versions in the same Heroku instance is not straightforward, we should run a purge or clean command to remove previously used gems and not fall on an issue. But why do we need to switch between them? is that our main reason for supporting Gemfile.next? I don't think so.

* Even without these changes some tests were failing locally, it might be because of a misconfiguration, I wonder if we should make those tests pass and add more tests with the new implementation.

QA NOTES:

1. Select a project that already has the [dual-boot configured](https://www.fastruby.io/blog/tags/dual-boot) and running.

2. In Heroku, go to the settings
![image](https://github.com/fastruby/heroku-buildpack-ruby/assets/7331511/e5f63710-10b7-4c53-8ed5-60b4e98afafc)

Remove the official `heroku/ruby` build pack and include our build pack `https://github.com/fastruby/heroku-buildpack-ruby#add_gemfile_next_support`

![image](https://github.com/fastruby/heroku-buildpack-ruby/assets/7331511/d1bc2baa-0b44-447d-aa2f-51dafa4c8d71)

Notice that right now we are using this branch to test the changes.

![image](https://github.com/fastruby/heroku-buildpack-ruby/assets/7331511/f9b73fab-bdae-40b6-87af-ef80b1ce43de)

3. Again, in the settings go to the config vars section and add `BUNDLE_GEMFILE` as a key and `Gemfile.next` as a value, then click add.

Make sure Heroku picks the value you set in the config vars sometimes this takes some time.

![image](https://github.com/fastruby/heroku-buildpack-ruby/assets/7331511/d8fb4d65-1f19-4580-9f8e-0324e2e5302e)

4. In the overview section you should see that you added a new config key

![image](https://github.com/fastruby/heroku-buildpack-ruby/assets/7331511/885a0682-1129-4470-a146-49c48e79768e)

5. Deploy the app, it should deploy the next version. since it would be hard to know what Rails version you are running with only seeing the web page, you can run `heroku run bash --app your_app_name` to get into the bash in Heroku.
then run the `rails --version`, `rails console`, `echo $BUNDLE_GEMFILE` or any other command that helps you know you are using the next Rails version.

